### PR TITLE
Fixing Tail Toxin effect duration from Kobold example mod.

### DIFF
--- a/Dawnsbury.Mods.Ancestries.Kobold/KoboldAncestryLoader.cs
+++ b/Dawnsbury.Mods.Ancestries.Kobold/KoboldAncestryLoader.cs
@@ -338,17 +338,18 @@ public static class KoboldAncestryLoader
                                     self.PersistentUsedUpResources.UsedUpActions.Add("Tail Toxin");
 
                                     // Set up the actual effect:
-                                    self.AddQEffect(new QEffect("Poisoned weapon", "Your next Strike with a piercing or slashing weapon deals extra persistent poison damage.", ExpirationCondition.ExpiresAtEndOfSourcesTurn, self, IllustrationName.AcidSplash)
+                                    QEffect tailToxinQEffect = new QEffect("Poisoned weapon", "Your next Strike with a piercing or slashing weapon deals extra persistent poison damage.", ExpirationCondition.ExpiresAtEndOfSourcesTurn, self, IllustrationName.AcidSplash);
+                                    tailToxinQEffect.CannotExpireThisTurn = true;
+                                    tailToxinQEffect.CountsAsBeneficialToSource = true;
+                                    tailToxinQEffect.AfterYouDealDamage = async (attacker, action, defender) =>
                                     {
-                                        CountsAsBeneficialToSource = true,
-                                        AfterYouDealDamage = async (attacker, action, defender) =>
+                                        if (action.Item?.WeaponProperties?.DamageKind == DamageKind.Piercing || action.Item?.WeaponProperties?.DamageKind == DamageKind.Slashing)
                                         {
-                                            if (action.Item?.WeaponProperties?.DamageKind == DamageKind.Piercing || action.Item?.WeaponProperties?.DamageKind == DamageKind.Slashing)
-                                            {
-                                                defender.AddQEffect(QEffect.PersistentDamage(attacker.Level.ToString(), DamageKind.Poison));
-                                            }
+                                            defender.AddQEffect(QEffect.PersistentDamage(attacker.Level.ToString(), DamageKind.Poison));
+                                            tailToxinQEffect.ExpiresAt = ExpirationCondition.Immediately;
                                         }
-                                    });
+                                    };
+                                    self.AddQEffect(tailToxinQEffect);
                                 })
                         ).WithPossibilityGroup(Constants.POSSIBILITY_GROUP_ADDITIONAL_NATURAL_STRIKE);
                     }


### PR DESCRIPTION
Tail Toxin is expiring in the end of the player's current turn instead of next turn, and the effect is not going away after the first strike.

From Tail Toxin's description in-game: "If your next Strike with that weapon before the end of your next turn hits and deals damage, you deal persistent poison damage equal to your level to the target."

From my testing the effect seems to line up with the description now, although I'm not sure this is the best way to fix this.

